### PR TITLE
fix issue with invalid control object

### DIFF
--- a/src/nav/facets.rs
+++ b/src/nav/facets.rs
@@ -21,14 +21,14 @@ pub(crate) fn consequences(
 
     let mut xs = vec![];
     let mut handle = ctl
-        .solve_mut_ref(clingo::SolveMode::YIELD, route)
+        .solve(clingo::SolveMode::YIELD, route)
         .ok()?;
 
     while let Ok(Some(ys)) = handle.model() {
         xs = ys.symbols(clingo::ShowType::SHOWN).ok()?;
         handle.resume().ok()?;
     }
-
+    let mut ctl = handle.close().ok().unwrap();
     ctl
         .configuration_mut()
         .map(|c| {

--- a/src/nav/facets.rs
+++ b/src/nav/facets.rs
@@ -8,7 +8,8 @@ pub(crate) fn consequences(
     route: &[SolverLiteral],
     kind: &str,
 ) -> Option<Vec<Symbol>> {
-    nav.ctl
+    let mut ctl = nav.ctl.take().unwrap(); // Take the control object out
+    ctl
         .configuration_mut()
         .map(|c| {
             c.root()
@@ -19,8 +20,7 @@ pub(crate) fn consequences(
         .ok()?;
 
     let mut xs = vec![];
-    let mut handle = nav
-        .ctl
+    let mut handle = ctl
         .solve_mut_ref(clingo::SolveMode::YIELD, route)
         .ok()?;
 
@@ -29,7 +29,7 @@ pub(crate) fn consequences(
         handle.resume().ok()?;
     }
 
-    nav.ctl
+    ctl
         .configuration_mut()
         .map(|c| {
             c.root()
@@ -38,7 +38,7 @@ pub(crate) fn consequences(
                 .ok()
         })
         .ok()?;
-
+    nav.ctl = Some(ctl); // Put the control object back
     Some(xs)
 }
 


### PR DESCRIPTION
Hi @drwadu ,
I tried to fix the issue. 
The underlying issue is that if a ClingoError occurs while solving the control object becomes invalid and should not be further used.
The current  API makes sure that the invalid control object can no longer  be accessed. So it made sense to put the control object in an option.
Of course you have some ugly unwraps in the code now that you might want to replace with proper error handling, but at least the tests are succeeding.